### PR TITLE
feat: allow fetching pwa prompt data without defaults

### DIFF
--- a/lib/components/pwa-prompt.test.tsx
+++ b/lib/components/pwa-prompt.test.tsx
@@ -9,30 +9,6 @@ import { userEvent } from '@testing-library/user-event';
 
 type iOSNavigator = Navigator & { standalone?: boolean };
 
-class LocalStorageMock {
-  store: Record<string, unknown> = {};
-
-  clear() {
-    this.store = {};
-  }
-
-  getItem(key: string) {
-    return this.store[key] || null;
-  }
-
-  setItem(key: string, value: unknown) {
-    this.store[key] = value + '';
-  }
-
-  removeItem(key: string) {
-    delete this.store[key];
-  }
-}
-
-Object.defineProperty(window, 'localStorage', {
-  value: new LocalStorageMock(),
-});
-
 describe('<PwaPrompt />', () => {
   beforeEach(() => {
     window.localStorage.clear();

--- a/lib/components/pwa-prompt.tsx
+++ b/lib/components/pwa-prompt.tsx
@@ -57,10 +57,13 @@ export const PwaPrompt = ({
   const onAfterDismiss = useCallback(
     (e: TransitionEvent) => {
       if (permanentlyHideOnDismiss)
-        setIosPwaPrompt((prevState) => ({
-          ...prevState,
-          visits: promptOnVisit + timesToShow,
-        }));
+        setIosPwaPrompt(
+          (prevState) =>
+            prevState && {
+              ...prevState,
+              visits: promptOnVisit + timesToShow,
+            }
+        );
 
       setIsDismissed(true);
 

--- a/lib/components/pwa-prompt.tsx
+++ b/lib/components/pwa-prompt.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState, type TransitionEvent } from 'react';
 
 import { Prompt } from './prompt.tsx';
-import { useUpdatePromptStorage } from '../hooks/use-update-prompt-storage.tsx';
+import { useUpdatePromptStorage } from '../hooks/use-update-prompt-storage.ts';
 import { useShouldShowPrompt } from '../main.ts';
 
 type PwaPromptProps = {

--- a/lib/hooks/use-should-show-prompt.spec.ts
+++ b/lib/hooks/use-should-show-prompt.spec.ts
@@ -1,0 +1,122 @@
+import { renderHook } from '@testing-library/react';
+import {
+  usePromptStorage,
+  useShouldShowPrompt,
+} from './use-should-show-prompt.ts';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { PromptLocalStorageKey } from '../main.ts';
+
+describe('usePromptStorage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns default values', () => {
+    const { result } = renderHook(() =>
+      usePromptStorage(PromptLocalStorageKey, false)
+    );
+
+    const [storageData] = result.current;
+    expect(storageData).toEqual({ isiOS: false, visits: 0 });
+  });
+
+  it('returns undefined if withOutDefaults is true and storage has not been updated', () => {
+    const { result } = renderHook(() =>
+      usePromptStorage(PromptLocalStorageKey, true)
+    );
+
+    const [storageData] = result.current;
+    expect(storageData).toBeUndefined();
+  });
+
+  it('returns prompt data from storage', () => {
+    localStorage.setItem(PromptLocalStorageKey, '{"isiOS":true,"visits":2}');
+
+    const { result } = renderHook(() =>
+      usePromptStorage(PromptLocalStorageKey, false)
+    );
+
+    const [storageData] = result.current;
+    expect(storageData).toEqual({ isiOS: true, visits: 2 });
+  });
+
+  it('returns prompt data from storage if withOutDefaults is true', () => {
+    localStorage.setItem(PromptLocalStorageKey, '{"isiOS":true,"visits":2}');
+
+    const { result } = renderHook(() =>
+      usePromptStorage(PromptLocalStorageKey, true)
+    );
+
+    const [storageData] = result.current;
+    expect(storageData).toEqual({ isiOS: true, visits: 2 });
+  });
+});
+
+describe('useShouldShowPrompt', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('should return false if iosPwaPrompt storage has not been updated', () => {
+    const { result } = renderHook(() =>
+      useShouldShowPrompt({ promptLocalStorageKey: PromptLocalStorageKey })
+    );
+
+    const { aboveMinVisits, belowMaxVisits, shouldShowPrompt } = result.current;
+    expect(aboveMinVisits).toBe(false);
+    expect(belowMaxVisits).toBe(true);
+    expect(shouldShowPrompt).toBe(false);
+  });
+
+  it('should return false if storage is defined but isiOS is false', () => {
+    localStorage.setItem(PromptLocalStorageKey, '{"isiOS":false,"visits":1}');
+
+    const { result } = renderHook(() =>
+      useShouldShowPrompt({ promptLocalStorageKey: PromptLocalStorageKey })
+    );
+
+    const { aboveMinVisits, belowMaxVisits, shouldShowPrompt } = result.current;
+    expect(aboveMinVisits).toBe(true);
+    expect(belowMaxVisits).toBe(true);
+    expect(shouldShowPrompt).toBe(false);
+  });
+
+  it('should return false if storage is defined but visits are below minimum', () => {
+    localStorage.setItem(PromptLocalStorageKey, '{"isiOS":true,"visits":0}');
+
+    const { result } = renderHook(() =>
+      useShouldShowPrompt({ promptLocalStorageKey: PromptLocalStorageKey })
+    );
+
+    const { aboveMinVisits, belowMaxVisits, shouldShowPrompt } = result.current;
+    expect(aboveMinVisits).toBe(false);
+    expect(belowMaxVisits).toBe(true);
+    expect(shouldShowPrompt).toBe(false);
+  });
+
+  it('should return true if storage is defined, isiOS is true, and visits are between min/max', () => {
+    localStorage.setItem(PromptLocalStorageKey, '{"isiOS":true,"visits":1}');
+
+    const { result } = renderHook(() =>
+      useShouldShowPrompt({ promptLocalStorageKey: PromptLocalStorageKey })
+    );
+
+    const { aboveMinVisits, belowMaxVisits, shouldShowPrompt } = result.current;
+    expect(aboveMinVisits).toBe(true);
+    expect(belowMaxVisits).toBe(true);
+    expect(shouldShowPrompt).toBe(true);
+  });
+
+  it('should return false if iosPwaPrompt is defined but visits is >= max', () => {
+    localStorage.setItem(PromptLocalStorageKey, '{"isiOS":true,"visits":2}');
+
+    const { result } = renderHook(() =>
+      useShouldShowPrompt({ promptLocalStorageKey: PromptLocalStorageKey })
+    );
+
+    const { aboveMinVisits, belowMaxVisits, shouldShowPrompt } = result.current;
+    expect(aboveMinVisits).toBe(true);
+    expect(belowMaxVisits).toBe(false);
+    expect(shouldShowPrompt).toBe(false);
+  });
+});

--- a/lib/hooks/use-should-show-prompt.ts
+++ b/lib/hooks/use-should-show-prompt.ts
@@ -45,6 +45,8 @@ export const useShouldShowPrompt = ({
     iosPwaPrompt && iosPwaPrompt.visits < promptOnVisit + timesToShow;
 
   return {
+    aboveMinVisits,
+    belowMaxVisits,
     iosPwaPrompt,
     setIosPwaPrompt,
     shouldShowPrompt: iosPwaPrompt?.isiOS && aboveMinVisits && belowMaxVisits,

--- a/lib/hooks/use-should-show-prompt.tsx
+++ b/lib/hooks/use-should-show-prompt.tsx
@@ -4,35 +4,49 @@ type UseShouldShowPromptProps = {
   promptLocalStorageKey: string;
   promptOnVisit?: number;
   timesToShow?: number;
+  withOutDefaults?: boolean;
 };
 
-export type PwaPromptData = {
-  isiOS: boolean;
-  visits: number;
-};
+export type PwaPromptData =
+  | {
+      isiOS: boolean;
+      visits: number;
+    }
+  | undefined;
 
-export const usePromptStorage = (promptLocalStorageKey: string) => {
-  return useLocalStorage<PwaPromptData>(promptLocalStorageKey, {
-    isiOS: false,
-    visits: 0,
-  });
+export const usePromptStorage = (
+  promptLocalStorageKey: string,
+  withOutDefaults: boolean
+) => {
+  return useLocalStorage<PwaPromptData>(
+    promptLocalStorageKey,
+    !withOutDefaults
+      ? {
+          isiOS: false,
+          visits: 0,
+        }
+      : undefined
+  );
 };
 
 export const useShouldShowPrompt = ({
   promptLocalStorageKey,
   promptOnVisit = 1,
   timesToShow = 1,
+  withOutDefaults = false,
 }: UseShouldShowPromptProps) => {
   const [iosPwaPrompt, setIosPwaPrompt] = usePromptStorage(
-    promptLocalStorageKey
+    promptLocalStorageKey,
+    withOutDefaults
   );
 
-  const aboveMinVisits = iosPwaPrompt.visits >= promptOnVisit;
-  const belowMaxVisits = iosPwaPrompt.visits < promptOnVisit + timesToShow;
+  const aboveMinVisits = iosPwaPrompt && iosPwaPrompt.visits >= promptOnVisit;
+  const belowMaxVisits =
+    iosPwaPrompt && iosPwaPrompt.visits < promptOnVisit + timesToShow;
 
   return {
     iosPwaPrompt,
     setIosPwaPrompt,
-    shouldShowPrompt: iosPwaPrompt.isiOS && aboveMinVisits && belowMaxVisits,
+    shouldShowPrompt: iosPwaPrompt?.isiOS && aboveMinVisits && belowMaxVisits,
   };
 };

--- a/lib/hooks/use-update-prompt-storage.ts
+++ b/lib/hooks/use-update-prompt-storage.ts
@@ -1,6 +1,6 @@
 import { useLayoutEffect } from 'react';
 import { useDeviceSelectors } from 'react-device-detect';
-import { PwaPromptData } from './use-should-show-prompt.tsx';
+import { PwaPromptData } from './use-should-show-prompt.ts';
 
 type UseUpdatePromptStorageProps = {
   setIosPwaPrompt: React.Dispatch<React.SetStateAction<PwaPromptData>>;

--- a/lib/hooks/use-update-prompt-storage.tsx
+++ b/lib/hooks/use-update-prompt-storage.tsx
@@ -26,7 +26,8 @@ export const useUpdatePromptStorage = ({
       const isiOS = deviceCheck(isIOS || isIPad13, window.navigator);
       setIosPwaPrompt((prevState) => ({
         isiOS,
-        visits: isiOS ? prevState.visits + 1 : prevState.visits,
+        visits:
+          isiOS && prevState ? prevState.visits + 1 : prevState?.visits || 0,
       }));
     }
   }, [setIosPwaPrompt, isIOS, isIPad13, skipStorageUpdate]);

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -21,5 +21,5 @@ export {
   usePromptStorage,
   useShouldShowPrompt,
   type PwaPromptData,
-} from './hooks/use-should-show-prompt.tsx';
-export { useUpdatePromptStorage } from './hooks/use-update-prompt-storage.tsx';
+} from './hooks/use-should-show-prompt.ts';
+export { useUpdatePromptStorage } from './hooks/use-update-prompt-storage.ts';


### PR DESCRIPTION
- aids in making decisions revolving around whether or not the prompt has initially been shown

- additional tests/test cleanup

- rename some files