### PR TITLE
feat: skip dupe builds

### DIFF
--- a/.github/workflows/build.js.yml
+++ b/.github/workflows/build.js.yml
@@ -7,7 +7,25 @@ on:
     branches: ['**']
 
 jobs:
+  change-detect:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
+    outputs:
+      duplicate_check: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          cancel_others: 'true'
+          concurrent_skipping: 'always'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule", "merge_group"]'
+
   build:
+    needs: change-detect
+    if: needs.change-detect.outputs.duplicate_check != 'true'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
- skip dupe builds
   - always prefer merge requests over push
   - do not skip merge groups