### PR TITLE
feat: add dismissed timestamp to storage

### DIFF
--- a/lib/components/pwa-prompt.test.tsx
+++ b/lib/components/pwa-prompt.test.tsx
@@ -1,5 +1,14 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 
 import { PwaPrompt } from './pwa-prompt.tsx';
 
@@ -10,9 +19,12 @@ import { userEvent } from '@testing-library/user-event';
 type iOSNavigator = Navigator & { standalone?: boolean };
 
 describe('<PwaPrompt />', () => {
-  beforeEach(() => {
-    window.localStorage.clear();
+  beforeAll(() => {
+    const date = new Date(2001, 0, 1);
+    vi.setSystemTime(date);
+  });
 
+  beforeEach(() => {
     vi.spyOn(rddExports, 'useDeviceSelectors').mockReturnValue([
       {
         isIOS: true,
@@ -22,6 +34,14 @@ describe('<PwaPrompt />', () => {
     vi.spyOn(window, 'navigator', 'get').mockReturnValue({
       standalone: false,
     } as iOSNavigator);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
   });
 
   it('renders Prompt if on an iOS browser not in standalone mode', async () => {
@@ -129,7 +149,7 @@ describe('<PwaPrompt />', () => {
     expect(screen.queryByTestId('prompt-overlay')).not.toBeInTheDocument();
     expect(screen.queryByTestId('prompt-wrapper')).not.toBeInTheDocument();
     expect(window.localStorage.getItem('iosPwaPrompt')).toEqual(
-      '{"isiOS":true,"visits":2}'
+      '{"isiOS":true,"visits":2,"dismissedAt":978336000000}'
     );
   });
 
@@ -151,7 +171,7 @@ describe('<PwaPrompt />', () => {
     expect(screen.queryByTestId('prompt-overlay')).not.toBeInTheDocument();
     expect(screen.queryByTestId('prompt-wrapper')).not.toBeInTheDocument();
     expect(window.localStorage.getItem('iosPwaPrompt')).toEqual(
-      '{"isiOS":true,"visits":2}'
+      '{"isiOS":true,"visits":2,"dismissedAt":978336000000}'
     );
   });
 
@@ -175,7 +195,7 @@ describe('<PwaPrompt />', () => {
     // Check if the onClose callback was called
     expect(onCloseMock).toHaveBeenCalledTimes(1);
     expect(window.localStorage.getItem('iosPwaPrompt')).toEqual(
-      '{"isiOS":true,"visits":2}'
+      '{"isiOS":true,"visits":2,"dismissedAt":978336000000}'
     );
   });
 
@@ -199,7 +219,7 @@ describe('<PwaPrompt />', () => {
     // Check if the onClose callback was called
     expect(onCloseMock).toHaveBeenCalledTimes(1);
     expect(window.localStorage.getItem('iosPwaPrompt')).toEqual(
-      '{"isiOS":true,"visits":2}'
+      '{"isiOS":true,"visits":2,"dismissedAt":978336000000}'
     );
   });
 });

--- a/lib/components/pwa-prompt.test.tsx
+++ b/lib/components/pwa-prompt.test.tsx
@@ -20,7 +20,7 @@ type iOSNavigator = Navigator & { standalone?: boolean };
 
 describe('<PwaPrompt />', () => {
   beforeAll(() => {
-    const date = new Date(2001, 0, 1);
+    const date = Date.UTC(2001, 0, 1);
     vi.setSystemTime(date);
   });
 
@@ -149,7 +149,7 @@ describe('<PwaPrompt />', () => {
     expect(screen.queryByTestId('prompt-overlay')).not.toBeInTheDocument();
     expect(screen.queryByTestId('prompt-wrapper')).not.toBeInTheDocument();
     expect(window.localStorage.getItem('iosPwaPrompt')).toEqual(
-      '{"isiOS":true,"visits":2,"dismissedAt":978336000000}'
+      '{"isiOS":true,"visits":2,"dismissedAt":978307200000}'
     );
   });
 
@@ -171,7 +171,7 @@ describe('<PwaPrompt />', () => {
     expect(screen.queryByTestId('prompt-overlay')).not.toBeInTheDocument();
     expect(screen.queryByTestId('prompt-wrapper')).not.toBeInTheDocument();
     expect(window.localStorage.getItem('iosPwaPrompt')).toEqual(
-      '{"isiOS":true,"visits":2,"dismissedAt":978336000000}'
+      '{"isiOS":true,"visits":2,"dismissedAt":978307200000}'
     );
   });
 
@@ -195,7 +195,7 @@ describe('<PwaPrompt />', () => {
     // Check if the onClose callback was called
     expect(onCloseMock).toHaveBeenCalledTimes(1);
     expect(window.localStorage.getItem('iosPwaPrompt')).toEqual(
-      '{"isiOS":true,"visits":2,"dismissedAt":978336000000}'
+      '{"isiOS":true,"visits":2,"dismissedAt":978307200000}'
     );
   });
 
@@ -219,7 +219,7 @@ describe('<PwaPrompt />', () => {
     // Check if the onClose callback was called
     expect(onCloseMock).toHaveBeenCalledTimes(1);
     expect(window.localStorage.getItem('iosPwaPrompt')).toEqual(
-      '{"isiOS":true,"visits":2,"dismissedAt":978336000000}'
+      '{"isiOS":true,"visits":2,"dismissedAt":978307200000}'
     );
   });
 });

--- a/lib/components/pwa-prompt.tsx
+++ b/lib/components/pwa-prompt.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, type TransitionEvent } from 'react';
+import { useCallback, type TransitionEvent } from 'react';
 
 import { Prompt } from './prompt.tsx';
 import { useUpdatePromptStorage } from '../hooks/use-update-prompt-storage.ts';
@@ -41,8 +41,6 @@ export const PwaPrompt = ({
   timesToShow = 1,
   transitionDuration = 400,
 }: PwaPromptProps) => {
-  const [isDismissed, setIsDismissed] = useState(false);
-
   const { shouldShowPrompt, setIosPwaPrompt } = useShouldShowPrompt({
     promptLocalStorageKey,
     promptOnVisit,
@@ -62,10 +60,9 @@ export const PwaPrompt = ({
             prevState && {
               ...prevState,
               visits: promptOnVisit + timesToShow,
+              dismissedAt: Date.now(),
             }
         );
-
-      setIsDismissed(true);
 
       if (onClose) onClose(e);
     },
@@ -78,11 +75,7 @@ export const PwaPrompt = ({
     ]
   );
 
-  if (
-    (!shouldShowPrompt || isDismissed || isOpen === false) &&
-    !isOpen === true
-  )
-    return null;
+  if ((!shouldShowPrompt || isOpen === false) && !isOpen === true) return null;
 
   return (
     <Prompt

--- a/lib/hooks/use-should-show-prompt.ts
+++ b/lib/hooks/use-should-show-prompt.ts
@@ -11,6 +11,7 @@ export type PwaPromptData =
   | {
       isiOS: boolean;
       visits: number;
+      dismissedAt?: number;
     }
   | undefined;
 
@@ -43,12 +44,17 @@ export const useShouldShowPrompt = ({
   const aboveMinVisits = iosPwaPrompt && iosPwaPrompt.visits >= promptOnVisit;
   const belowMaxVisits =
     iosPwaPrompt && iosPwaPrompt.visits < promptOnVisit + timesToShow;
+  const shouldShowPrompt =
+    iosPwaPrompt?.isiOS &&
+    !iosPwaPrompt?.dismissedAt &&
+    aboveMinVisits &&
+    belowMaxVisits;
 
   return {
     aboveMinVisits,
     belowMaxVisits,
     iosPwaPrompt,
     setIosPwaPrompt,
-    shouldShowPrompt: iosPwaPrompt?.isiOS && aboveMinVisits && belowMaxVisits,
+    shouldShowPrompt,
   };
 };

--- a/lib/hooks/use-should-show-prompt.ts
+++ b/lib/hooks/use-should-show-prompt.ts
@@ -9,9 +9,9 @@ type UseShouldShowPromptProps = {
 
 export type PwaPromptData =
   | {
-      isiOS: boolean;
-      visits: number;
-      dismissedAt?: number;
+      isiOS: boolean; // represents whether or not the device is considered iphone/ipad
+      visits: number; // represents current prompt render (visit) count
+      dismissedAt?: number; // represents when the user dismissed the prompt as a UTC epoch
     }
   | undefined;
 

--- a/lib/hooks/use-update-prompt-storage.ts
+++ b/lib/hooks/use-update-prompt-storage.ts
@@ -1,9 +1,9 @@
-import { useLayoutEffect } from 'react';
+import { Dispatch, SetStateAction, useLayoutEffect } from 'react';
 import { useDeviceSelectors } from 'react-device-detect';
 import { PwaPromptData } from './use-should-show-prompt.ts';
 
 type UseUpdatePromptStorageProps = {
-  setIosPwaPrompt: React.Dispatch<React.SetStateAction<PwaPromptData>>;
+  setIosPwaPrompt: Dispatch<SetStateAction<PwaPromptData>>;
   skipStorageUpdate?: boolean;
 };
 
@@ -25,9 +25,10 @@ export const useUpdatePromptStorage = ({
     if (!skipStorageUpdate) {
       const isiOS = deviceCheck(isIOS || isIPad13, window.navigator);
       setIosPwaPrompt((prevState) => ({
+        ...prevState,
         isiOS,
         visits:
-          isiOS && prevState ? prevState.visits + 1 : prevState?.visits || 0,
+          isiOS && prevState ? prevState.visits + 1 : (prevState?.visits ?? 0),
       }));
     }
   }, [setIosPwaPrompt, isIOS, isIPad13, skipStorageUpdate]);

--- a/lib/hooks/use-update-prompt-storage.ts
+++ b/lib/hooks/use-update-prompt-storage.ts
@@ -20,16 +20,21 @@ export const useUpdatePromptStorage = ({
 }: UseUpdatePromptStorageProps) => {
   const [{ isIOS, isIPad13 }] = useDeviceSelectors(window.navigator.userAgent);
 
-  // runs once on mount, determines if iOS/iPadOS and increments visit counter
+  // determines if iOS/iPadOS and increments visit counter
   useLayoutEffect(() => {
     if (!skipStorageUpdate) {
       const isiOS = deviceCheck(isIOS || isIPad13, window.navigator);
-      setIosPwaPrompt((prevState) => ({
-        ...prevState,
-        isiOS,
-        visits:
-          isiOS && prevState ? prevState.visits + 1 : (prevState?.visits ?? 0),
-      }));
+      setIosPwaPrompt((prevState) => {
+        const currentVisits = prevState?.visits ?? 0;
+        return {
+          ...prevState,
+          isiOS,
+          visits:
+            isiOS && !prevState?.dismissedAt
+              ? currentVisits + 1
+              : currentVisits,
+        };
+      });
     }
   }, [setIosPwaPrompt, isIOS, isIPad13, skipStorageUpdate]);
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/thenick775/react-ios-pwa-prompt-ts.git"
+    "url": "git+https://github.com/thenick775/react-ios-pwa-prompt-ts.git"
   },
   "main": "./dist/react-ios-pwa-prompt-ts.umd.cjs",
   "module": "./dist/react-ios-pwa-prompt-ts.js",


### PR DESCRIPTION
- adds dismissed timestamp to prompt data

- refactors counter increment

- ran fix on package.json

note: prep for reappearance interval, preps for prop change to be more understandable for a wider variety of use cases